### PR TITLE
feat: add factory project assistant dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,81 +1,711 @@
-
 <!DOCTYPE html>
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>刷题练习系统</title>
+  <title>工厂工程项目工作助理</title>
   <style>
-    body { font-family: Arial, sans-serif; padding: 20px; max-width: 700px; margin: auto; line-height: 1.6; }
-    h2 { margin-bottom: 10px; }
-    button { margin: 6px 0; padding: 10px 15px; font-size: 16px; cursor: pointer; }
-    .option { display: block; margin-bottom: 8px; }
-    .feedback { margin-top: 12px; font-weight: bold; }
+    :root {
+      color-scheme: light;
+      --bg: #f5f6fa;
+      --panel: #ffffff;
+      --primary: #1f6feb;
+      --accent: #f08300;
+      --border: #d0d7de;
+      --text-muted: #57606a;
+    }
+
+    body {
+      font-family: "Segoe UI", "Microsoft YaHei", sans-serif;
+      margin: 0;
+      padding: 24px;
+      background: var(--bg);
+      color: #24292f;
+    }
+
+    header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 28px;
+    }
+
+    header p {
+      margin: 0;
+      color: var(--text-muted);
+      max-width: 740px;
+    }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 18px;
+      box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+    }
+
+    .card h3 {
+      margin: 0 0 12px;
+      font-size: 16px;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    .card strong {
+      font-size: 28px;
+      line-height: 1.1;
+      color: #111827;
+    }
+
+    .controls {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    form {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 18px;
+      display: grid;
+      gap: 12px;
+    }
+
+    form h2 {
+      margin: 0;
+      font-size: 20px;
+    }
+
+    label {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-muted);
+    }
+
+    input,
+    select,
+    textarea {
+      width: 100%;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 14px;
+      background: #fff;
+    }
+
+    textarea {
+      min-height: 70px;
+      resize: vertical;
+    }
+
+    button {
+      border: none;
+      border-radius: 8px;
+      padding: 10px 14px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: transform 0.1s ease, box-shadow 0.1s ease;
+    }
+
+    button.primary {
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 6px 16px rgba(31, 111, 235, 0.22);
+    }
+
+    button.secondary {
+      background: #eef2ff;
+      color: #3730a3;
+    }
+
+    button.danger {
+      background: #fee2e2;
+      color: #b91c1c;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+    }
+
+    .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+
+    .filters button {
+      border: 1px solid var(--border);
+      background: #fff;
+      color: #1f2937;
+    }
+
+    .filters button.active {
+      border-color: var(--primary);
+      color: var(--primary);
+      font-weight: 600;
+    }
+
+    .project-list {
+      display: grid;
+      gap: 16px;
+    }
+
+    .project-item {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 18px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .project-header {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .status[data-status="进行中"] {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .status[data-status="待确认"] {
+      background: #fef3c7;
+      color: #b45309;
+    }
+
+    .status[data-status="已完成"] {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+
+    .status[data-status="已归档"] {
+      background: #e5e7eb;
+      color: #374151;
+    }
+
+    .status[data-status="风险"] {
+      background: #fee2e2;
+      color: #b91c1c;
+    }
+
+    .project-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 8px 18px;
+      font-size: 14px;
+      color: var(--text-muted);
+    }
+
+    .project-next-step {
+      background: #f1f5f9;
+      border-radius: 10px;
+      padding: 12px;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    .project-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .reminders,
+    .suggestions {
+      margin-top: 28px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .empty-state {
+      text-align: center;
+      color: var(--text-muted);
+      padding: 24px;
+      border: 1px dashed var(--border);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.7);
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 16px;
+      }
+
+      .project-meta {
+        grid-template-columns: 1fr;
+      }
+    }
   </style>
 </head>
 <body>
-  <div id="quiz"></div>
+  <header>
+    <h1>工厂工程项目工作助理</h1>
+    <p>
+      跟踪项目进展、提醒未完成事项、自动生成优化建议，帮助你更高效地管理工厂工程项目。
+      所有数据保存在浏览器本地，方便在日常工作中随时记录。
+    </p>
+  </header>
+
+  <section class="summary-grid" id="summary"></section>
+
+  <section class="controls">
+    <form id="projectForm">
+      <h2>新增项目</h2>
+      <label>项目名称
+        <input id="projectName" required placeholder="例如：生产线自动化改造" />
+      </label>
+      <label>客户 / 车间
+        <input id="projectClient" placeholder="某工厂三车间" />
+      </label>
+      <label>负责人
+        <input id="projectOwner" placeholder="张工" />
+      </label>
+      <label>完成节点
+        <input id="projectDue" type="date" required />
+      </label>
+      <label>优先级
+        <select id="projectPriority">
+          <option value="高">高</option>
+          <option value="中" selected>中</option>
+          <option value="低">低</option>
+        </select>
+      </label>
+      <label>当前阶段
+        <input id="projectStage" placeholder="需求确认 / 方案设计 / 安装调试" />
+      </label>
+      <label>下一步 &amp; 计划日期
+        <input id="projectNextStep" placeholder="联系供应商确认交期" />
+        <input id="projectNextStepDate" type="date" />
+      </label>
+      <label>备注
+        <textarea id="projectNotes" placeholder="补充注意事项，例如需要协调的部门"></textarea>
+      </label>
+      <button type="submit" class="primary">保存项目</button>
+    </form>
+
+    <div class="card" id="quickTips">
+      <h3>优化建议速览</h3>
+      <p id="tipsContent" style="margin: 0; line-height: 1.6;">
+        根据项目的优先级与进度，系统会给出跟进节奏、资源配置等建议。
+      </p>
+    </div>
+  </section>
+
+  <section>
+    <div class="filters" id="filters"></div>
+    <div class="project-list" id="projectList"></div>
+  </section>
+
+  <section class="reminders" id="reminders"></section>
+  <section class="suggestions" id="suggestions"></section>
 
   <script>
-    const questions = [{"id": 1, "question": "计算机主存一般由半导体存储器组成，按读写特性可以分为", "options": ["ROM和RAM", "高速和低速", "Cache和RAM", "RAM和BIOS"], "answer": "ROM和RAM"}, {"id": 2, "question": "嵌入式系统一般包括                 、外围硬件设备以及特定            序等几个部分，是集软、硬件为一体的可独立工作的器件", "options": ["嵌入式微处理\n器", "控制器", "运算器", "存储器"], "answer": "嵌入式微处理\n器"}, {"id": 3, "question": "汇编语言是一种", "options": ["依赖于计算机\n的低级程序设\n计语言", "计算机能直接\n执行的程序设\n计语言", "独立于计算机\n的高级程序设\n计语言", "面向对象的程\n序设计语言"], "answer": "依赖于计算机\n的低级程序设\n计语言"}, {"id": 4, "question": "矢量图形文件是用           描述图像的", "options": ["文本", "矩阵", "线段与曲线", "数组"], "answer": "线段与曲线"}, {"id": 5, "question": "以下存储器，使用光介质来存储数据的是", "options": ["U盘", "移动硬盘", "RAM", "DVD"], "answer": "DVD"}, {"id": 6, "question": "在计算机领域，媒体分为             这几类", "options": ["感觉媒体、表\n示媒体、表现\n媒体、存储媒\n体和传输媒体", "动画媒体、语\n言媒体和声音\n媒体", "硬件媒体和软\n件媒体", "信息媒体、文\n字媒体和图像\n媒体"], "answer": "感觉媒体、表\n示媒体、表现\n媒体、存储媒\n体和传输媒体"}, {"id": 7, "question": "操作系统的主要功能是              和用户界面管理", "options": ["文件管理", "资源管理", "安全管理", "图标管理"], "answer": "资源管理"}, {"id": 8, "question": "人工智能的目的是让机器能够            ，以实现某些脑力劳动的机械化", "options": ["具有完全的智\n能", "和人脑一样考\n虑问题", "完全代替人", "模拟、延伸和\n扩展人的智能"], "answer": "模拟、延伸和\n扩展人的智能"}, {"id": 9, "question": "CPU内包含有控制器和         两部分", "options": ["运算器", "存储器", "BIOS", "接口"], "answer": "运算器"}, {"id": 10, "question": "汉字输入码可分为有", "options": ["全拼码", "自然码", "区位码", "简拼码"], "answer": "区位码"}, {"id": 11, "question": "智能手机的硬件层主要由三大部分组成，分别是通信子系统、电源管理子系统和应用子系统，其中                        是核心", "options": ["通信子系统", "电源管理子系\n统", "应用子系统", "移动通信网络"], "answer": "应用子系统"}, {"id": 12, "question": "以下不属于云计算的主要技术的是", "options": ["虚拟化技术", "编程模型", "分布式海量数\n据存储技术", "信息安全"], "answer": "信息安全"}, {"id": 13, "question": "BIOS程序的主要作用是", "options": ["保护计算机中\n的软件", "加速CPU的运\n算速度", "增加ROM的读\n写速度", "开机自检并加\n载基本的驱动\n程序"], "answer": "开机自检并加\n载基本的驱动\n程序"}, {"id": 14, "question": "计算机辅助设计的简称是", "options": ["CAT", "CAM", "CAI", "CAD"], "answer": "CAD"}, {"id": 15, "question": "近代信息技术的发展先导是_______的突破", "options": ["信息传播技术", "文字传播技术", "语言技术", "记录技术"], "answer": "信息传播技术"}, {"id": 16, "question": "在汉字库中查找汉字时，输入的是汉字的机内码，输出的是汉字的", "options": ["交换码", "信息码", "外码", "字形码"], "answer": "字形码"}, {"id": 17, "question": "______区块链是", "options": ["通过去中心化\n和去信任的方\n式集体维护一\n个可靠数据库\n的方案。", "中心化数据库", "电脑程序", "一个街区"], "answer": "通过去中心化\n和去信任的方\n式集体维护一\n个可靠数据库\n的方案。"}, {"id": 18, "question": "计算机的三大应用领域是", "options": ["科学计算、信\n息处理和过程\n控制", "计算、打字和\n家教", "科学计算、辅\n助设计和辅助\n教学", "信息处理、办\n公自动化和家\n教"], "answer": "科学计算、信\n息处理和过程\n控制"}, {"id": 19, "question": "十进制数678转换为二进制数是", "options": ["1101100001", "1011100011", "1100110011", "1010100110"], "answer": "1010100110"}, {"id": 20, "question": "通常用后缀字母来标识某数的进位制，字母B代表", "options": ["十六进制", "十进制", "八进制", "二进制"], "answer": "二进制"}, {"id": 21, "question": "下列软件中，属于应用软件的是", "options": ["WORD", "DOS", "WINDOWS", "UNIX"], "answer": "WORD"}, {"id": 22, "question": "在物联网的关键技术中，射频识别（RFID）是一种", "options": ["信息采集技术", "无线传输技术", "自组织组网技\n术", "中间件技术"], "answer": "信息采集技术"}, {"id": 23, "question": "多媒体是指", "options": ["多种传播介质", "以多种媒体形\n式来传播信息", "多种存储介质", "存储在光盘中\n的信息"], "answer": "以多种媒体形\n式来传播信息"}, {"id": 24, "question": "多媒体技术不具有的特性是", "options": ["集成性", "实时性", "智能性", "交互性"], "answer": "智能性"}, {"id": 25, "question": "软件与程序的区别是", "options": ["程序价格便\n宜，软件价格\n昂贵", "程序是用户自\n己编写的，而\n软件是由厂家\n提供的", "程序是用高级\n语言编写的，\n而软件是由机\n器语言编写的", "软件是程序、\n数据结构和文\n档的总称，而\n程序只是软件\n的一部分"], "answer": "软件是程序、\n数据结构和文\n档的总称，而\n程序只是软件\n的一部分"}, {"id": 26, "question": "语言、音乐、图形、动画、文字等都是", "options": ["表现媒体", "显示媒体", "感觉媒体", "传输媒体"], "answer": "感觉媒体"}, {"id": 27, "question": "数字字符3的ASCⅡ码为十进制数51，数字字符9的ASCⅡ的十进制数为", "options": ["55", "56", "57", "58"], "answer": "57"}, {"id": 28, "question": "数字签名的_______功能是指签名可以证明是签名者而不是其他人在文件上签字", "options": ["签名不可伪造", "签名不可变更", "签名不可抵赖", "签名是可信的"], "answer": "签名不可伪造"}, {"id": 29, "question": "在多媒体系统中，内存和光盘属于             媒体", "options": ["感觉", "传输", "表现", "存储"], "answer": "存储"}, {"id": 30, "question": "__________是人工智能的重要应用", "options": ["数据库", "操作系统", "固态硬盘", "机器翻译"], "answer": "机器翻译"}, {"id": 31, "question": "以下关于防火墙的说法中错误的是", "options": ["提供访问控制\n功能", "防火墙是一种\n确保网络安全\n的工具", "可以防止信息\n泄露", "防火墙可以抵\n挡所有病毒的\n入侵"], "answer": "防火墙可以抵\n挡所有病毒的\n入侵"}, {"id": 32, "question": "第五代移动通讯技术（5th generation mobile networks，5G）是最新一代              移动通讯技术", "options": ["蜂窝", "WIFI", "WAPI", "蓝牙技术"], "answer": "蜂窝"}, {"id": 33, "question": "在计算机术语中经常用RAM表示", "options": ["随机存取存储\n器", "可编程只读存\n储器", "动态随机存储\n器", "只读存储"], "answer": "随机存取存储\n器"}, {"id": 34, "question": "国际通用的ASCⅡ码的码长是", "options": ["7", "8", "12", "16"], "answer": "7"}, {"id": 35, "question": "不是大数据预处理技术", "options": ["数据可视化", "数据抽取", "数据清洗", "数据集成"], "answer": "数据可视化"}, {"id": 36, "question": "目前应用愈来愈广泛的优盘属于          技术", "options": ["刻录", "移动存储", "网络存储", "直接连接存储"], "answer": "移动存储"}, {"id": 37, "question": "在网络安全中，常用的关键技术可以归纳为              三大类", "options": ["计划、检测、\n防范", "规划、监督、\n组织", "检测、防范、\n监督", "预防保护、检\n测跟踪、响应\n恢复"], "answer": "预防保护、检\n测跟踪、响应\n恢复"}, {"id": 38, "question": "近代信息技术发展阶段的特征是以_______为主角的信息传输技术", "options": ["书信", "光", "电", "红外"], "answer": "电"}, {"id": 39, "question": "以下关于ROM的说法错误的是", "options": ["CPU不能向ROM\n随机写入数据\n。", "ROM中的内容\n在断电后不会\n丢失。", "ROM是只读\n的，所以它属\n于外存储器而\n不是内存储器", "ROM是只读存\n储器的英文缩\n写。"], "answer": "ROM是只读\n的，所以它属\n于外存储器而\n不是内存储器"}, {"id": 40, "question": "以下不属于区块链的主要技术的有", "options": ["密码学", "共识机制", "智能合约", "大数据"], "answer": "大数据"}, {"id": 41, "question": "与外存相比，RAM具有          的优点", "options": ["速度快", "容量大", "不怕断电", "存储在其内的\n数据将永久保\n存"], "answer": "速度快"}, {"id": 42, "question": "不属于区块链的主要技术", "options": ["密码学", "共识机制", "虚拟现实", "智能合约"], "answer": "虚拟现实"}, {"id": 43, "question": "3D打印机是一种", "options": ["输入设备", "输出设备", "计算部件", "存储设备"], "answer": "输出设备"}, {"id": 44, "question": "图灵在计算机方面的主要贡献有建立图灵机和提出", "options": ["图灵测试", "图灵结构", "图灵设计", "图灵方案"], "answer": "图灵测试"}, {"id": 45, "question": "以下不属于计算思维的应用领域的是", "options": ["生物学", "脑科学", "化学", "物理"], "answer": "物理"}, {"id": 46, "question": "下列            不属于云计算的主要技术", "options": ["虚拟化技术", "搜索技术", "分布式海量数\n据存储技术", "海量数据管理\n技术"], "answer": "搜索技术"}, {"id": 47, "question": "下列叙述中，正确的是", "options": ["用高级程序语\n言编写的程序\n称为源程序", "计算机能直接\n识别并执行用\n汇编语言编写\n的程序", "机器语言编写\n的程序执行效\n率最低", "高级语言编写\n的程序的可移\n植性最差"], "answer": "用高级程序语\n言编写的程序\n称为源程序"}, {"id": 48, "question": "若已知一汉字的国标码是5E38，则其内码是", "options": ["DEB8", "DE38", "5EB8", "5E38"], "answer": "DEB8"}, {"id": 49, "question": "光盘驱动器通过激光束来读取光盘上的信息，这时的激光头和光盘盘面", "options": ["直接接触", "不直接接触", "有时接触有时\n不接触", "其他都不正确"], "answer": "不直接接触"}, {"id": 50, "question": "对于一幅1920×1080像素，24位真彩色的图像，在没有压缩的情况下，其所占存储空间约________字节", "options": ["49MB", "6MB", "2MB", "1MB"], "answer": "6MB"}, {"id": 51, "question": "不属于World Wide Web核心标准的是", "options": ["统一资源标识\n符（URL）", "超文本传输协\n议（HTTP）", "超文本标记语\n言（HTML）", "脚本语言\n（JavaScript）"], "answer": "脚本语言\n（JavaScript）"}, {"id": 52, "question": "当网络中任何一个工作站发生故障时，都有可能导致整个网络停止工作，这种网络的拓扑结构为        结构", "options": ["星型", "树型", "总线型", "环型"], "answer": "环型"}, {"id": 53, "question": "射频识别的英文简称是", "options": ["RFID", "RIDF", "RFDI", "RDFI"], "answer": "RFID"}, {"id": 54, "question": "第五代移动通信系统（5G）网络的理论峰值传输速度可以达到", "options": ["5Gb/s", "8Gb/s", "10Gb/s", "12Gb/s"], "answer": "10Gb/s"}, {"id": 55, "question": "域名与IP地址一一对应，Internet是靠        完成这种对应关系的", "options": ["TCP", "PING", "DNS", "IP"], "answer": "DNS"}, {"id": 56, "question": "连接在Internet上的计算机，下列描述错误的是", "options": ["一台计算机可\n以有一个或多\n个IP地址", "可以两台计算\n机共用一个IP\n地址", "每台计算机都\n有不同的IP地\n址", "计算机的IP地\n址是其在在\nInternet上的\n唯一标识"], "answer": "可以两台计算\n机共用一个IP\n地址"}, {"id": 57, "question": "_______是移动通信设备与因特网之间的通信标准，可实现在移动通信设备上直接访问因特网", "options": ["WLAN", "CDMA", "5G", "WAP"], "answer": "WAP"}, {"id": 58, "question": "计算机的备份对象主要是系统备份和", "options": ["数据恢复", "数据备份", "数据安全", "源代码"], "answer": "数据备份"}, {"id": 59, "question": "在局域网中要实现资源共享必须安装         组件", "options": ["服务器", "无线网卡", "IPv6协议", "共享和打印服\n务"], "answer": "共享和打印服\n务"}, {"id": 60, "question": "在IE浏览器中载入新的Web页，可通过        操作", "options": ["在地址框中输\n入新的Web地\n址", "单击工具栏上\n的\"\"刷新\"\"按\n扭", "单击工具栏上\n的\"\"全屏\"\"按\n扭", "单击工具栏上\n的\"\"停止\"\"按\n扭"], "answer": "在地址框中输\n入新的Web地\n址"}, {"id": 61, "question": "随着物联网的发展，传感器也越来越智能化，不仅可以采集外部信息，还能利用嵌入的             进行信息处理", "options": ["运算器", "感应器", "微处理机", "存储器"], "answer": "微处理机"}, {"id": 62, "question": "________是广域网的英文缩写", "options": ["LAN", "MAN", "WAN", "CYN"], "answer": "WAN"}, {"id": 63, "question": "下列关于计算机病毒的叙述中，正确的是", "options": ["反病毒软件可\n以查、杀任何\n种类的病毒", "计算机病毒是\n一种被破坏了\n的程序", "反病毒软件必\n须随着新病毒\n的出现而升\n级，提高查、\n杀病毒的功能", "感染过计算机\n病毒的计算机\n具有对该病毒\n的免疫性"], "answer": "反病毒软件必\n须随着新病毒\n的出现而升\n级，提高查、\n杀病毒的功能"}, {"id": 64, "question": "下列关于计算机病毒的叙述中，正确的选项是", "options": ["计算机病毒只\n感染.exe\n或.com文件", "计算机病毒可\n以通过读写U\n盘、光盘或\nInternet网络\n进行传播", "计算机病毒是\n通过电力网进\n行传播的", "计算机病毒是\n由于软盘片表\n面不清洁而造\n成的。"], "answer": "计算机病毒可\n以通过读写U\n盘、光盘或\nInternet网络\n进行传播"}, {"id": 65, "question": "FTP协议实现的基本功能是", "options": ["远程登录", "邮件发送", "邮件接收", "文件传输"], "answer": "文件传输"}, {"id": 66, "question": "能够让两个不同类型的网络相互通信的网络互连设备是指", "options": ["集线器", "交换机", "网关", "路由器"], "answer": "网关"}, {"id": 67, "question": "如果使用IE上网浏览网站信息，使用的是互联网的________服务", "options": ["FTP", "Telnet", "电子邮件", "WWW"], "answer": "WWW"}, {"id": 68, "question": "以下无线通讯方式中，传输距离最近的是", "options": ["蓝牙", "RFID", "NFC", "红外"], "answer": "NFC"}, {"id": 69, "question": "在计算机网络中，通常把提供并管理共享资源的计算机称为", "options": ["工作站", "服务器", "网关", "网桥"], "answer": "服务器"}, {"id": 70, "question": "广域网采用的网络拓扑结构通常是        结构", "options": ["总线", "环形", "星型", "网状"], "answer": "网状"}, {"id": 71, "question": "以下不属于保护计算机资源重要手段的是", "options": ["配置备份", "设置防火墙", "磁片整理", "防治病毒"], "answer": "磁片整理"}, {"id": 72, "question": "衡量数据通信系统特性的技术指标不包括", "options": ["传输速率", "差错率", "数据总量", "可靠性"], "answer": "数据总量"}, {"id": 73, "question": "数据是信息的载体，  一般用             代码表示", "options": ["英文", "二进制", "数字", "信息"], "answer": "二进制"}, {"id": 74, "question": "当A用户向B用户成功发送电子邮件后，B用户电脑没有开机，那么B用户的电子邮件将       。______", "options": ["退回给发信人", "保存在B用户\n对应的邮件服\n务器上", "过一会对方再\n重新发送", "永远不再发送"], "answer": "保存在B用户\n对应的邮件服\n务器上"}, {"id": 75, "question": "将内网与外网相隔离，  是提供信息安全服务，  实现网络和信息安全的重要基础设备", "options": ["防火墙", "安全检查", "DeFender", "OneDrive"], "answer": "防火墙"}, {"id": 76, "question": "Windows环境下，              命令可用于查看本机的网络配置信息", "options": ["ipconfig", "ping", "arp", "netstat"], "answer": "ipconfig"}, {"id": 77, "question": "物联网三项关键技术不包括", "options": ["传感器技术", "电子标签", "嵌入式系统技\n术", "空间定位技术"], "answer": "空间定位技术"}, {"id": 78, "question": "以下不是计算机网络最基本的功能的是", "options": ["数据通信", "资源共享", "协同工作", "数据计算"], "answer": "数据计算"}, {"id": 79, "question": "使用互联网接入服务时，电子信箱的地址一般是由           提供的", "options": ["Outlook\nExpress", "ISP", "浏览器", "IP协议"], "answer": "ISP"}, {"id": 80, "question": "发送设备将信息转换成信道上的数字信号的操作称为", "options": ["解调", "解码", "编码", "调制"], "answer": "编码"}, {"id": 81, "question": "在Windows中，下列关于文件夹窗口说法正确的是", "options": ["在详细信息窗\n格中可以给文\n字处理文件添\n加作者、标记\n等信息", "在预览窗格中\n可以预览图片\n文件，而且能\n修改", "在地址栏中不\n能显示绝对路\n径", "在文件夹窗口\n中不可以显示\n地址栏"], "answer": "在详细信息窗\n格中可以给文\n字处理文件添\n加作者、标记\n等信息"}, {"id": 82, "question": "操作系统是对计算机系统的的硬件和软件资源进行管理和控制的程序，它是_____的接口", "options": ["主机与外设", "源程序和目标\n程序", "用户和计算机", "硬件和软件"], "answer": "用户和计算机"}, {"id": 83, "question": "在Windows中，在搜索栏中输入“*.txt”，则搜索的是", "options": ["含有*号的文\n件或文件夹", "含有“*.txt”文\n字的文件和文\n件夹", "txt类型的文件", "含有“txt”文字\n的文件和文件\n夹"], "answer": "txt类型的文件"}, {"id": 84, "question": "在Windows中，文件的扩展名表示", "options": ["文件的大小", "文件的作者", "文件的类型", "文件的存放位\n置"], "answer": "文件的类型"}, {"id": 85, "question": "在Windows中屏幕保护程序的作用是", "options": ["节能功能", "美化屏幕功能", "安全功能", "提供节能和系\n统安全功能"], "answer": "提供节能和系\n统安全功能"}, {"id": 86, "question": "__________负责为用户建立文件，  存入、读出、修改、转储文件，  控制文件的存取等", "options": ["资源管理器", "文件管理器", "资源系统", "文件系统"], "answer": "文件系统"}, {"id": 87, "question": "在Windows中，不能对任务栏进行的操作是", "options": ["改变尺寸大小", "移动位置", "删除", "隐藏"], "answer": "删除"}, {"id": 88, "question": "Windows中的回收站，往往是用来保护        中被删除的文件或文件夹", "options": ["内存", "硬盘", "U盘", "光盘"], "answer": "硬盘"}, {"id": 89, "question": "在Windows中，如果需要把文件在打印的时候以prn扩展名保存，则需要选择            功能", "options": ["打印机端口", "打印到文件", "串行端口", "本地端口"], "answer": "打印到文件"}, {"id": 90, "question": "在Windows中，打开相关应用程序，在选取某一菜单后，若菜单项后面带有省略号“ …”,则表示", "options": ["将弹出对话框", "已被删除", "当前不能使用", "该菜单项正在\n起作用"], "answer": "将弹出对话框"}, {"id": 91, "question": "Windows操作系统安装完成后，在桌面可使用“_______键+鼠标上下滚轮”，调整桌面图标的大小", "options": ["Alt", "Ctrl", "Shift", "Enter"], "answer": "Ctrl"}, {"id": 92, "question": "在Windows中，以下叙述正确的是", "options": ["“记事本”软件\n是一个文字处\n理软件，它可\n以处理大型而\n且格式复杂的\n文档", "“记事本”软件\n中无法在文本\n中插入一个图\n片", "“画图”软件中\n无法在图片上\n添加文字", "“画图”软件最\n多可使用256\n种颜色画图，\n所以无法处理\n真彩色的图片"], "answer": "“记事本”软件\n中无法在文本\n中插入一个图\n片"}, {"id": 93, "question": "在Windows 10中，要显示任务视图，应按_____快捷键", "options": ["Win+Tab", "Win+空格", "Win+Alt", "Ctrl+Alt"], "answer": "Win+Tab"}, {"id": 94, "question": "在Windows 中，用户文件的属性不包括          类型", "options": ["只读", "只写", "隐藏", "存档"], "answer": "只写"}, {"id": 95, "question": "当一个应用程序的窗口被最小化后，该应用程序将", "options": ["继续在桌面运\n行", "仍然在内存中\n运行", "被终止运行", "被暂停运行"], "answer": "仍然在内存中\n运行"}, {"id": 96, "question": "_______取代了文件分配表文件系统，成为目前Windows操作系统的主要文件系统", "options": ["FAT", "DOS", "NTFS", "FAT32"], "answer": "NTFS"}, {"id": 97, "question": "在Windows中，打开“设备管理器”操作正确的是", "options": ["“控制面板”|“硬\n件和声音”", "右键单击“开\n始”菜单，单\n击“设备管理", "右键单击任务\n栏，“属性”|“设\n备管理器”", "右键单击桌\n面，“管理”|“设\n备管理器”"], "answer": "右键单击“开\n始”菜单，单\n击“设备管理"}, {"id": 98, "question": "在Windows中，当计算机连接的打印机无法打印时，可将打印机设置为“________”功能", "options": ["延迟打印", "打印到文件", "暂停打印", "保存为PDF"], "answer": "打印到文件"}, {"id": 99, "question": "Windows系统中常用的文件系统包括", "options": ["FAT和APFS", "ExtFAT和NTFS", "VFAT和HFS", "FAT和NTFS"], "answer": "FAT和NTFS"}, {"id": 100, "question": "在Windows中，键盘上可以实现将屏幕复制下来的按键是", "options": ["ScrLK", "Pause", "PrtScn", "Enter"], "answer": "PrtScn"}, {"id": 101, "question": "在Windows的文件资源管理器中，在不同的磁盘中拖动文件，所完成的是              操作", "options": ["文件的移动", "文件的复制", "文件的粘贴", "文件名的修改"], "answer": "文件的复制"}, {"id": 102, "question": "在Windows中，下列关于文件和文件夹的说法中不正确的是", "options": ["在同一个文件\n夹中可以存在\nMYFILE.txt和\nmyfile.txt两个\n文件", "在不同的文件\n夹中可以存在\nMYFILE.txt和\nmyfile.txt两个\n文件", "在同一个文件\n夹中可以存在\nMYFILE.doc和\nmyfile.txt两个\n文件", "在不同的文件\n夹中可以存在\nmyfile.txt和\nmyfile.txt两个\n文件"], "answer": "在同一个文件\n夹中可以存在\nMYFILE.txt和\nmyfile.txt两个\n文件"}, {"id": 103, "question": "关于库功能的说法，下列错误的是", "options": ["库中可以添加\n硬盘上的任意\n文件夹", "库中文件夹里\n的文件保存在\n原来的地方", "库中添加的是\n指向文件夹的\n快捷方式", "库中文件夹的\n文件被彻底移\n动到库中"], "answer": "库中文件夹的\n文件被彻底移\n动到库中"}, {"id": 104, "question": "Windows中的用户账户Administrator是", "options": ["来宾账户", "受限账户", "无密码账户", "管理员账户"], "answer": "管理员账户"}, {"id": 105, "question": "在Windows中，标题栏是位于窗口最上端的带状条，用于说明当前窗口的", "options": ["内容主题", "时间", "状态", "输入法"], "answer": "内容主题"}, {"id": 106, "question": "Windows 10的_______位于桌面底部，包含工具栏、按钮区、通知区、显示桌面按钮等部分", "options": ["开始菜单", "状态栏", "任务栏", "控制面板"], "answer": "任务栏"}, {"id": 107, "question": "在Windows中，要搜索所有文件名以“ZX”开头的文本文件，应该在搜索框中输入_____", "options": ["ZX?.txt", "ZX*.txt", "ZX*.*", "ZX?.?"], "answer": "ZX*.txt"}, {"id": 108, "question": "在Windows系统中操作时，鼠标右击对象，则", "options": ["可以打开一个\n对象的窗口", "激活该对象", "复制该对象的\n备份", "弹出针对该对\n象操作的快捷\n菜单"], "answer": "弹出针对该对\n象操作的快捷\n菜单"}, {"id": 109, "question": "在Windows中，如果要调整日期时间，可以鼠标右击任务栏中的_______，然后从快捷菜单中选择“调整日期/时间”命令", "options": ["桌面空白处", "任务栏空白处", "任务栏通知区", "通知区日期/\n时间"], "answer": "通知区日期/\n时间"}, {"id": 110, "question": "在Windows操作系统中，显示桌面的快捷键是", "options": ["Win+Tab", "Alt+Tab", "Win+D", "Win+P"], "answer": "Win+D"}, {"id": 111, "question": "在电子表格工作表中，不正确的单元格地址是", "options": ["66", "$C66", "C6$6", "$C$66"], "answer": "C6$6"}, {"id": 112, "question": "在电子表格中，公式“AVERAGE($A$3:$A$10)”中的$A$3表示的是        引用方式", "options": ["交叉", "混合", "相对", "绝对"], "answer": "绝对"}, {"id": 113, "question": "在Excel中，进行分类汇总操作时首先应按照要分类的关键字段进行", "options": ["筛选", "查找", "排序", "计算"], "answer": "排序"}, {"id": 114, "question": "菜单项呈灰度显示，表明", "options": ["对话框", "不可选择", "有下级菜单", "有联级菜单"], "answer": "不可选择"}, {"id": 115, "question": "以下关于“分类汇总”和“数据透视表”的叙述不正确的是", "options": ["使用分类汇总\n可自动对数据\n进行分级显示", "使用分类汇总\n时不用区分分\n类字段及汇总\n方式", "数据透视表具\n有强大的数据\n重组和数据分\n析能力", "数据透视表创\n建后可以更改\n创建数据透视\n表的数据源"], "answer": "使用分类汇总\n时不用区分分\n类字段及汇总\n方式"}, {"id": 116, "question": "在Excel中，连接文本数据的运算符是", "options": ["@", "#", "(", "&"], "answer": "&"}, {"id": 117, "question": "在电子表格中，要返回两个日期之间相差的天数、月数或者年数，可以使用            函数", "options": ["EDATE", "MONTH", "TODAY", "DATEDIF"], "answer": "DATEDIF"}, {"id": 118, "question": "电子表格中可通过选择        组合键来输入当前时间", "options": ["Ctrl+t", "Alt+t", "Ctrl+Shift+;", "Tab+t"], "answer": "Ctrl+Shift+;"}, {"id": 119, "question": "在电子表格中，完成数据筛选时", "options": ["只显示符合条\n件的第一个记\n录", "显示数据清单\n中的全部记录", "只显示不符合\n条件的记录", "只显示符合条\n件的记录"], "answer": "只显示符合条\n件的记录"}, {"id": 120, "question": "在Excel中，如果在单元格D2中输入了公式“=A2+B2”，把该公式复制到E2单元格，则E2单元格中的公式将为", "options": ["“=B2+C2\"", "\"=C2+D2\"", "\"=A2+B2\"", "\"=D2+E2\""], "answer": "“=B2+C2\""}, {"id": 121, "question": "如果将选定单元格（或区域）的内容消除，但单元格依然保留的操作，称为", "options": ["重定", "清除", "改变", "删除"], "answer": "清除"}, {"id": 122, "question": "下列_______软件属于电子表格处理软件", "options": ["Minitab", "LaTeX", "Microsoft\nOffice Word", "iWork Pages"], "answer": "Minitab"}, {"id": 123, "question": "建立电子表格的主要目的，不是简单的建一个表格，而是", "options": ["为了整齐、美\n观，便于查阅", "便于数据档案\n管理", "为了实现数据\n分析等比较复\n杂的运输", "为了实现办公\n电子化"], "answer": "为了实现数据\n分析等比较复\n杂的运输"}, {"id": 124, "question": "单元格C3中输入公式为“=IF(AND(B3>=9.9,B3<=10.1),\"合格\",\"不合格\")”，若B3的值为10，则单元格C3显示", "options": ["合格", "不合格", "10", "错误标记"], "answer": "合格"}, {"id": 125, "question": "电子表格中，可通过_____个工作簿视图方式来查看数据", "options": ["4", "3", "6", "8"], "answer": "4"}, {"id": 126, "question": "在电子表格中，数据管理与分析的对象为数据清单，有关数据清单错误的说法是         。_______", "options": ["避免在数据清\n单中放入空白\n行和列", "数据清单中必\n须设置列标题\n或行标题", "数据清单中各\n列标题或行标\n题不可相同", "一个工作表上\n可以有多个数\n据清单"], "answer": "一个工作表上\n可以有多个数\n据清单"}, {"id": 127, "question": "在电子表格中输入文本时，将自动        对齐", "options": ["左", "右", "居中", "分散"], "answer": "左"}, {"id": 128, "question": "Excel中求平均数的函数是", "options": ["SUM", "MAX", "AVERAGE", "COUNT"], "answer": "AVERAGE"}, {"id": 129, "question": "电子表格工作表中若有公式“AVERAGE(A1:C5)”，当删除第二行数据后该公式将变为       。______", "options": ["AVERAGE(A1:\nC4)", "AVERAGE(C12:\nE12)", "AVERAGE(C12:\nE12)", "无变化"], "answer": "AVERAGE(A1:\nC4)"}, {"id": 130, "question": "数据透视图是针对______显示的汇总数据而实行的一种图解表示方法", "options": ["数据表", "工作表", "数据透视表", "分类汇总表"], "answer": "数据透视表"}, {"id": 131, "question": "PDF文件的基础是______图像模型", "options": ["EnCase", "C++", "PHP", "PostScrip"], "answer": "PostScrip"}, {"id": 132, "question": "以下不属于电子表格单元格区域引用的是", "options": ["交叉引用", "混合引用", "相对引用", "绝对引用"], "answer": "交叉引用"}, {"id": 133, "question": "在电子表格中进行分类汇总时，不是其汇总的方式的是", "options": ["求和", "计数", "平均值", "除法"], "answer": "除法"}, {"id": 134, "question": "在电子表格中，若要对工作表重新命名，可采用", "options": ["单击工作表标\n签", "双击工作表标\n签", "单击表格标题\n行", "双击表格标题\n行"], "answer": "双击工作表标\n签"}, {"id": 135, "question": "在电子表格的编辑状态中，打开文档“ABC”，修改后另存为“CBA”，则文档“ABC”         。_______", "options": ["被文档CBA覆\n盖", "未修改被关闭", "被修改并关闭", "被修改未关闭"], "answer": "未修改被关闭"}, {"id": 136, "question": "将B102单元格的公式“=SUM(B2:B101)”复制到单元格C102，则单元格C102中的公式为           。_________", "options": ["“\n\n=SUM(B2:B10\n1)”", "“\n\n=SUM(B3:B10\n2)”", "“\n\n=SUM(C2:C10\n1)”", "“\n\n=SUM(C3:C10\n2)”"], "answer": "“\n\n=SUM(C2:C10\n1)”"}, {"id": 137, "question": "利用Excel软件对数据进行的排序不包括", "options": ["简单排序", "复杂排序", "单元格排序", "自定义排序"], "answer": "单元格排序"}, {"id": 138, "question": "在Excel中，如果用$D$7来引用工作表D列第7行的单元格，称为对单元格的", "options": ["交叉引用", "相对引用", "混合引用", "绝对引用"], "answer": "绝对引用"}, {"id": 139, "question": "SmartArt图形包含", "options": ["流程图", "关系图", "矩阵图", "全部"], "answer": "全部"}, {"id": 140, "question": "在创建分类汇总前，必须根据分类字段对数据列表进行", "options": ["筛选", "排序", "计算", "指定"], "answer": "排序"}, {"id": 141, "question": "在使用Word过程中，可随时按键盘上的_______键以获得联机帮助", "options": ["F1", "Alt", "Ctrl", "Shift"], "answer": "F1"}, {"id": 142, "question": "利用“字体”对话框不可以完成的操作是", "options": ["设置字体", "设置字间距", "设置文字效果", "设置首行缩进"], "answer": "设置首行缩进"}, {"id": 143, "question": "在文字操作表格中，对当前单元格左边的所有单元格中的数值求和，应使用        公式", "options": ["SUM\n（RIGHT）", "SUM\n（BELOW）", "SUM（LEFT）", "SUM\n（ABOVE）"], "answer": "SUM（LEFT）"}, {"id": 144, "question": "文字操作编辑状态下，对于选定文字，", "options": ["可移动，不可\n复制", "可复制，不可\n移动", "可移动或复制", "可同时进行移\n动复制"], "answer": "可移动或复制"}, {"id": 145, "question": "SmartArt图形包含", "options": ["流程图", "关系图", "矩阵图", "全部"], "answer": "全部"}, {"id": 146, "question": "Word 2016中提供了          ，支持手写公式的图像识别", "options": ["手绘公式", "鼠标公式", "墨迹公式", "形状公式"], "answer": "墨迹公式"}, {"id": 147, "question": "可以实现文档中局部文字的横排、竖排以及图文混排效果", "options": ["文本框", "图片", "表格", "文档部件"], "answer": "文本框"}, {"id": 148, "question": "在文字操作中要显示分页效果，应切换到           视图方式下", "options": ["普通", "大纲", "页面", "主控文档"], "answer": "页面"}, {"id": 149, "question": "如果需要在文档中自行绘制比较简单的示意图，可以利用________功能完成", "options": ["图片", "形状", "SmartArt", "图表"], "answer": "形状"}, {"id": 150, "question": "使用              可以很方便地完成长文档中快速定位、重排结构、切换标题等操作", "options": ["目录", "文档导航", "样式", "标签"], "answer": "文档导航"}, {"id": 151, "question": "选定文字操作中表格的一行，再执行“开始”选项卡中的“剪切”命令，则", "options": ["将该行各单元\n格的内容删\n除，变成空白", "删除该行，表\n格减少一行", "将该行的边框\n删除，保留文\n字", "在该行合并表\n格"], "answer": "将该行各单元\n格的内容删\n除，变成空白"}, {"id": 152, "question": "默认情况下，自动目录可以提取             级别的目录", "options": ["标题1", "标题2", "标题3", "标题4"], "answer": "标题4"}, {"id": 153, "question": "当前正在编辑的文字操作文档的名称显示在窗口的        中", "options": ["标题栏", "菜单栏", "工具栏", "状态栏"], "answer": "标题栏"}, {"id": 154, "question": "艺术字对象实际是", "options": ["文字对象", "图形对象", "特殊对象", "链接对象"], "answer": "图形对象"}, {"id": 155, "question": "用户对Word文档的部分内容要进行注释和说明，需要为文档作", "options": ["脚注", "题注", "批注", "尾注"], "answer": "批注"}, {"id": 156, "question": "在Word中，表述错误的是", "options": ["选择文件功能\n区中的打印选\n项可以进行页\n面设置", "表格和文本可\n以互相转换", "可以给文本选\n择各种样式，\n并且可以更改\n样式", "页边距不能通\n过标尺进行设\n置"], "answer": "页边距不能通\n过标尺进行设\n置"}, {"id": 157, "question": "打印预览可以预览的页数是", "options": ["只能预览1页", "只能预览2页", "只能预览3页", "可以预览多页"], "answer": "可以预览多页"}, {"id": 158, "question": "如果制作标签，信封，成绩单，可以用文字操作中特有的        选项卡", "options": ["审阅", "页面布局", "引用", "邮件"], "answer": "邮件"}, {"id": 159, "question": "在Word中，如果需要更新以自动更新形式插入的日期和时间，应该按下键盘的_______键", "options": ["F4", "F9", "F1", "F8"], "answer": "F9"}, {"id": 160, "question": "与Word相比较，LaTex在______更优秀", "options": ["公式排版", "文字排版", "图像排版", "语音转换"], "answer": "公式排版"}, {"id": 161, "question": "在Word中，项目符号和编号是对于________来添加的", "options": ["整篇文档", "段落", "行", "节"], "answer": "段落"}, {"id": 162, "question": "在文字操作中改变图片大小的本质其实就是", "options": ["改变图片内容", "按比例放大或\n缩小", "只是一种显示\n效果", "对图片剪裁"], "answer": "按比例放大或\n缩小"}, {"id": 163, "question": "新建文字操作文件的快捷键是", "options": ["Ctrl+O", "Ctrl+S", "Ctrl+N", "Ctrl+V"], "answer": "Ctrl+N"}, {"id": 164, "question": "如果文档很长，那么用户可以用文字操作提供的_____技术，同时在二个窗口中滚动查看同一文档的不同部分", "options": ["拆分窗口", "滚动条", "排列窗口", "帮助"], "answer": "拆分窗口"}, {"id": 165, "question": "在文字操作中，为把文档中的一段文字转换为表格，要求这些文字每行里的各部分         。_______", "options": ["必须用逗号分\n开", "必须用空格分\n开", "必须用制表符\n分开", "可以用其他选\n项的任意一种\n符号或其他符\n号分隔开"], "answer": "可以用其他选\n项的任意一种\n符号或其他符\n号分隔开"}, {"id": 166, "question": "在文字操作的编辑状态下，执行两次“剪切”操作，则在剪贴板中", "options": ["仅有第一次被\n剪切的内容", "仅有第二次被\n剪切的内容", "两次被剪切的\n内容都有", "内容被消除"], "answer": "两次被剪切的\n内容都有"}, {"id": 167, "question": "在文字操作中选择某语句后，连续单击两次工具栏中的“加粗”按钮，则", "options": ["这句话呈粗体\n格式", "这句话呈细体\n格式", "这句话格式不\n变", "产生错误报告"], "answer": "这句话格式不\n变"}, {"id": 168, "question": "在文字操作中，每个段落的标记在", "options": ["段落中无法看\n到", "段落的结尾处", "段落的中部", "段落的开始处"], "answer": "段落的结尾处"}, {"id": 169, "question": "在文字操作中，如果使用了项目符号或编号，则项目符号或编号在        时会自动出现", "options": ["每次按回车键", "一行文字输入\n完毕并回车", "按Tab键", "文字输入超过\n右边界"], "answer": "一行文字输入\n完毕并回车"}, {"id": 170, "question": "在文字操作中,若要计算表格中某行数值的总和，可使用的统计函数是", "options": ["SUM()", "TOTAL()", "COUNT()", "AVERAGE()"], "answer": "SUM()"}, {"id": 171, "question": "在PowerPoint中，为了使所有幻灯片具有统一的、特有的外观风格，可通过设置_______来实现", "options": ["幻灯片版式", "样式", "主题", "母版"], "answer": "母版"}, {"id": 172, "question": "在PowerPoint中，若要在每张幻灯片相同位置都显示公司Logo图片，应在           中进行图片插入操作", "options": ["普通视图", "幻灯片母版", "幻灯片浏览视\n图", "阅读视图"], "answer": "幻灯片母版"}, {"id": 173, "question": "在PowerPoint 2016中，单击“_______”选项卡“媒体”组中的“音频”或“视频”按钮后，会自动显示“音频（视频）工具/格式”和“音频（视频）工具/播放”动态选项卡", "options": ["设计", "动画", "插入", "视图"], "answer": "插入"}, {"id": 174, "question": "PowerPoint中可以影响所有幻灯片效果的，不包含以下的", "options": ["改变母版", "改变动画", "改变主题", "改变切换"], "answer": "改变动画"}, {"id": 175, "question": "关于PowerPoint中的主题样式，下列说法中错误的是", "options": ["主题样式能够\n使演示文稿的\n整体效果更好\n美观", "用户一旦选择\n的主题样式，\n就不能自定义\n对象的颜色、\n字体等效果", "主题样式包括\n预设了颜色、\n字体、背景、\n效果样式等", "主题样式是针\n对整个演示文\n稿，而不是某\n张幻灯片"], "answer": "用户一旦选择\n的主题样式，\n就不能自定义\n对象的颜色、\n字体等效果"}, {"id": 176, "question": "不是PowerPoint能保存的文件格式的扩展名", "options": ["potx", "wmv", "pptx", "dbk"], "answer": "dbk"}, {"id": 177, "question": "在PowerPoint中有关动画效果的设置，说法错误的是", "options": ["动画效果类型\n有：进入、退\n出、强调和自\n定义", "同一个对象可\n同时设置多个\n动画效果", "可设置各个动\n画效果的时间\n、顺序和播放\n控制", "通过设置触发\n器来实现人机\n交互"], "answer": "动画效果类型\n有：进入、退\n出、强调和自\n定义"}, {"id": 178, "question": "下列不是PowerPoint能保存的文件格式扩展名的是", "options": ["potx", "wmv", "pptx", "dbk"], "answer": "dbk"}, {"id": 179, "question": "PowerPoint触发器动画除使用鼠标单击对象的方式触发外，还可以使用_______来触发动画", "options": ["书签", "节", "切换", "动画刷"], "answer": "书签"}, {"id": 180, "question": "PowerPoint模板是以扩展名________保存的包含版式、主题颜色、主题字体、主题效果和背景样式的一张或一组幻灯片文件", "options": ["ppt", "pptx", "potx", "ppot"], "answer": "potx"}, {"id": 181, "question": "PowerPoint中可以影响所有幻灯片效果的，不包含", "options": ["改变母版", "改变动画", "改变主题", "改变切换"], "answer": "改变动画"}, {"id": 182, "question": "PowerPoint中编辑时可以多次被不同文档使用的是", "options": ["母版", "模板", "版式", "节"], "answer": "模板"}, {"id": 183, "question": "在PowerPoint中，为了能预先统计出放映整个演示文稿和每张幻灯片所需的大致时间，我们可以采用设置", "options": ["排练计时", "自定义放映", "换片方式", "放映类型"], "answer": "排练计时"}, {"id": 184, "question": "PowerPoint中，从外部复制的文字，不可以用哪种粘贴选项进行粘贴", "options": ["图片", "纯文本", "保留原格式", "嵌入"], "answer": "嵌入"}, {"id": 185, "question": "PowerPoint中编辑时可以多次被不同文档使用的是", "options": ["母版", "模板", "版式", "节"], "answer": "模板"}, {"id": 186, "question": "PowerPoint触发器动画除使用鼠标单击对象的方式触发外，还可以使用     来触发动画", "options": ["书签", "节", "切换", "动画刷"], "answer": "书签"}, {"id": 187, "question": "在PowerPoint 2016中，利用_______可以将幻灯片分组，从而增强幻灯片管理的层次性", "options": ["节", "编号", "页码", "母版"], "answer": "节"}, {"id": 188, "question": "PowerPoint中编辑时可以多次被不同文档使用的是", "options": ["母版", "模板", "版式", "节"], "answer": "模板"}, {"id": 189, "question": "PowerPoint中，从外部复制的文字，不可以用哪种粘贴选项进行粘贴", "options": ["图片", "纯文本", "保留原格式", "嵌入"], "answer": "嵌入"}, {"id": 190, "question": "PowerPoint中动作路径动画分为三类，不包含", "options": ["基本", "直线和曲线", "特殊", "细微型"], "answer": "细微型"}, {"id": 191, "question": "PowerPoint模板的扩展名为", "options": [".pptx", ".pdf", ".potx", ".xps"], "answer": ".potx"}, {"id": 192, "question": "PowerPoint可导出的其他类型的文件有", "options": ["PDF、MP3、\nGIF、Word文\n档等", "PDF、GIF、\nJPG、Excel等", "PDF、GIF、\nMP4、GIF等", "PDF、MP4、\nJPG、BMP等"], "answer": "PDF、GIF、\nMP4、GIF等"}, {"id": 193, "question": "在PowerPoint浏览视图下，按住Ctrl键并拖动某张幻灯片，所完成的操作是", "options": ["移动幻灯片", "复制幻灯片", "删除幻灯片", "隐藏幻灯片"], "answer": "复制幻灯片"}, {"id": 194, "question": "PowerPoint触发器动画除使用鼠标单击对象的方式触发外，还可以使用_________来触发动画", "options": ["书签", "节", "切换", "动画期"], "answer": "书签"}, {"id": 195, "question": "PowerPoint文档打印时不能选择的颜色效果是", "options": ["灰度", "纯黑白", "颜色", "RGB色"], "answer": "RGB色"}, {"id": 196, "question": "在PowerPoint中，若要使演示文稿中的各张幻灯片按规定的时间长短，实现连续的自动播放，应进行", "options": ["设置放映方式", "幻灯片切换", "排练计时", "打包操作"], "answer": "排练计时"}, {"id": 197, "question": "PowerPoint支持在主题选定后，更改配色方案。配色方案设置不包括以下_______选项", "options": ["文字", "背景", "超链接", "动画"], "answer": "动画"}, {"id": 198, "question": "在PowerPoint 2016中，           是一组统一的设计元素，它使用颜色、字体和效果来设置所有幻灯片的外观", "options": ["背景", "主题", "格式", "模板"], "answer": "主题"}, {"id": 199, "question": "PowerPoint文档打印时不能选择的颜色效果是", "options": ["灰度", "纯黑白", "颜色", "RGB色"], "answer": "RGB色"}, {"id": 200, "question": "在PowerPoint中，可以使用多个______来组织大型幻灯片版面，方便导航，简化管理", "options": ["母版", "版式", "节", "定位"], "answer": "节"}];
+    const filters = [
+      { key: "all", label: "全部项目" },
+      { key: "进行中", label: "进行中" },
+      { key: "待确认", label: "待确认" },
+      { key: "已完成", label: "已完成" },
+      { key: "已归档", label: "已归档" },
+      { key: "风险", label: "风险预警" }
+    ];
 
-    let current = 0;
-    let score = 0;
-    let wrong = [];
-    let answered = false;
+    const storageKey = "factory-projects-v1";
+    const storedProjects = JSON.parse(localStorage.getItem(storageKey) || "null");
 
-    function render() {
-      const q = questions[current];
-      let html = "<h2>第 " + (current + 1) + " 题：" + q.question + "</h2><div id='options'>";
-      q.options.forEach((opt, i) => {
-        html += "<button class='option' onclick='choose(`" + opt.replace(/`/g, "\`") + "`)'>" + String.fromCharCode(65 + i) + ". " + opt + "</button>";
+    const projects = storedProjects || [
+      {
+        id: crypto.randomUUID(),
+        name: "包装线自动化升级",
+        client: "一分厂包装车间",
+        owner: "张伟",
+        status: "进行中",
+        stage: "设备选型",
+        priority: "高",
+        dueDate: "2024-06-30",
+        nextStep: "确认机器人抓手定制图纸",
+        nextStepDate: "2024-05-28",
+        notes: "需协调供应商现场勘测时间。",
+        lastUpdated: "2024-05-20"
+      },
+      {
+        id: crypto.randomUUID(),
+        name: "污水处理系统维保",
+        client: "公共工程部",
+        owner: "李婷",
+        status: "待确认",
+        stage: "年度计划审批",
+        priority: "中",
+        dueDate: "2024-05-31",
+        nextStep: "等待财务批复维保预算",
+        nextStepDate: "2024-05-24",
+        notes: "涉及环保验收，需提前准备资料。",
+        lastUpdated: "2024-05-18"
+      },
+      {
+        id: crypto.randomUUID(),
+        name: "仓储货架安全整改",
+        client: "物流部",
+        owner: "王强",
+        status: "风险",
+        stage: "施工准备",
+        priority: "高",
+        dueDate: "2024-05-25",
+        nextStep: "确认停产窗口并安排施工队伍",
+        nextStepDate: "2024-05-22",
+        notes: "安全隐患较大，需提前完成员工培训。",
+        lastUpdated: "2024-05-21"
+      },
+      {
+        id: crypto.randomUUID(),
+        name: "中央空调节能改造",
+        client: "行政后勤部",
+        owner: "周敏",
+        status: "已完成",
+        stage: "项目验收",
+        priority: "中",
+        dueDate: "2024-04-30",
+        nextStep: "整理能源消耗对比报告",
+        nextStepDate: "2024-05-05",
+        notes: "节能率达成 12%，待归档报告。",
+        lastUpdated: "2024-05-08"
+      },
+      {
+        id: crypto.randomUUID(),
+        name: "喷漆房除尘系统升级",
+        client: "车身车间",
+        owner: "刘洋",
+        status: "已归档",
+        stage: "资料归档",
+        priority: "低",
+        dueDate: "2024-03-15",
+        nextStep: "存档施工资料并回收合同",
+        nextStepDate: "2024-03-20",
+        notes: "作为标准项目案例，可供培训使用。",
+        lastUpdated: "2024-03-22"
+      }
+    ];
+
+    let currentFilter = "all";
+
+    const summaryEl = document.getElementById("summary");
+    const filtersEl = document.getElementById("filters");
+    const projectListEl = document.getElementById("projectList");
+    const remindersEl = document.getElementById("reminders");
+    const suggestionsEl = document.getElementById("suggestions");
+    const tipsEl = document.getElementById("tipsContent");
+
+    function persistProjects() {
+      localStorage.setItem(storageKey, JSON.stringify(projects));
+    }
+
+    function parseDate(str) {
+      return str ? new Date(str) : null;
+    }
+
+    function formatDate(str) {
+      if (!str) return "--";
+      const date = parseDate(str);
+      if (Number.isNaN(date?.getTime())) return str;
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    }
+
+    function calcSummary() {
+      const total = projects.length;
+      const inProgress = projects.filter((p) => p.status === "进行中").length;
+      const pending = projects.filter((p) => p.status === "待确认").length;
+      const archived = projects.filter((p) => p.status === "已完成" || p.status === "已归档").length;
+      const highRisk = projects.filter((p) => p.status === "风险").length;
+      const dueSoon = projects.filter((p) => isDueWithin(p, 7)).length;
+      return { total, inProgress, pending, archived, highRisk, dueSoon };
+    }
+
+    function isDueWithin(project, days) {
+      if (["已完成", "已归档"].includes(project.status)) return false;
+      const due = parseDate(project.dueDate);
+      if (!due) return false;
+      const today = new Date();
+      const diff = (due - today) / (1000 * 60 * 60 * 24);
+      return diff < days && diff >= 0;
+    }
+
+    function isOverdue(project) {
+      if (["已完成", "已归档"].includes(project.status)) return false;
+      const due = parseDate(project.dueDate);
+      if (!due) return false;
+      const today = new Date();
+      return due < new Date(today.toDateString());
+    }
+
+    function buildSummary() {
+      const { total, inProgress, pending, archived, highRisk, dueSoon } = calcSummary();
+      const summaryCards = [
+        { title: "项目总数", value: total },
+        { title: "进行中", value: inProgress },
+        { title: "待确认/待推进", value: pending },
+        { title: "已完成/归档", value: archived },
+        { title: "风险项目", value: highRisk },
+        { title: "即将到期(7天)", value: dueSoon }
+      ];
+
+      summaryEl.innerHTML = summaryCards
+        .map(
+          (card) => `
+            <div class="card">
+              <h3>${card.title}</h3>
+              <strong>${card.value}</strong>
+            </div>
+          `
+        )
+        .join("");
+    }
+
+    function renderFilters() {
+      filtersEl.innerHTML = filters
+        .map(
+          (filter) => `
+            <button type="button" data-filter="${filter.key}" class="${currentFilter === filter.key ? "active" : ""}">
+              ${filter.label}
+            </button>
+          `
+        )
+        .join("");
+
+      filtersEl.querySelectorAll("button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          currentFilter = btn.dataset.filter;
+          renderProjects();
+        });
       });
-      html += "</div><div id='feedback' class='feedback'></div>";
-      document.getElementById("quiz").innerHTML = html;
     }
 
-    function choose(opt) {
-      if (answered) return;
-      answered = true;
-      const q = questions[current];
-      const feedbackEl = document.getElementById("feedback");
+    function filteredProjects() {
+      if (currentFilter === "all") return [...projects];
+      return projects.filter((p) => p.status === currentFilter);
+    }
 
-      if (opt === q.answer) {
-        score++;
-        feedbackEl.innerHTML = "✅ 回答正确！";
-      } else {
-        wrong.push(q);
-        feedbackEl.innerHTML = "❌ 回答错误。正确答案是：<b>" + q.answer + "</b>";
+    function renderProjects() {
+      const list = filteredProjects();
+
+      if (!list.length) {
+        projectListEl.innerHTML = '<div class="empty-state">暂无符合条件的项目</div>';
+        return;
       }
 
-      document.getElementById("options").innerHTML += "<br/><button onclick='next()'>下一题</button>";
+      projectListEl.innerHTML = list
+        .map((project) => {
+          const overdue = isOverdue(project);
+          const dueClass = overdue ? "color: #b91c1c; font-weight: 600;" : "";
+          const nextStepHighlight = project.nextStepDate && isDueWithin(project, 3)
+            ? "background: #fef3c7;"
+            : "";
+
+          return `
+            <div class="project-item">
+              <div class="project-header">
+                <div>
+                  <strong>${project.name}</strong>
+                  <span class="status" data-status="${project.status}">${project.status}</span>
+                </div>
+                <div style="color: var(--text-muted); font-size: 13px;">
+                  最近更新：${formatDate(project.lastUpdated)}
+                </div>
+              </div>
+              <div class="project-meta">
+                <div>客户/部门：${project.client || "--"}</div>
+                <div>负责人：${project.owner || "--"}</div>
+                <div style="${dueClass}">目标完成：${formatDate(project.dueDate)}</div>
+                <div>当前阶段：${project.stage || "--"}</div>
+                <div>优先级：${project.priority}</div>
+              </div>
+              <div class="project-next-step" style="${nextStepHighlight}">
+                <strong>下一步：</strong>${project.nextStep || "请补充下一步计划"}
+                ${project.nextStepDate ? `（计划日期：${formatDate(project.nextStepDate)}）` : ""}
+              </div>
+              <div style="font-size: 14px; color: var(--text-muted);">
+                备注：${project.notes || "--"}
+              </div>
+              <div class="project-actions">
+                ${["已完成", "已归档"].includes(project.status)
+                  ? ""
+                  : `<button class="secondary" data-action="complete" data-id="${project.id}">标记完成</button>`
+                }
+                ${project.status !== "已归档"
+                  ? `<button class="secondary" data-action="archive" data-id="${project.id}">归档</button>`
+                  : ""
+                }
+                <button class="primary" data-action="update" data-id="${project.id}">更新跟进</button>
+                <button class="danger" data-action="remove" data-id="${project.id}">删除</button>
+              </div>
+            </div>
+          `;
+        })
+        .join("");
+
+      projectListEl.querySelectorAll("button").forEach((btn) => {
+        btn.addEventListener("click", () => handleAction(btn.dataset.action, btn.dataset.id));
+      });
     }
 
-    function next() {
-      current++;
-      answered = false;
-      if (current >= questions.length) {
-        const result = wrong.length === 0
-          ? "<h2>🎉 全部答对！</h2>"
-          : "<h2>完成练习！答对 " + score + "/" + questions.length + " 题</h2><button onclick='retry()'>重新练错题</button>";
-        document.getElementById("quiz").innerHTML = result;
-      } else {
-        render();
+    function renderReminders() {
+      const overdueProjects = projects.filter(isOverdue);
+      const dueSoonProjects = projects.filter((p) => isDueWithin(p, 5));
+
+      if (!overdueProjects.length && !dueSoonProjects.length) {
+        remindersEl.innerHTML = "";
+        return;
       }
+
+      remindersEl.innerHTML = `
+        <div class="card">
+          <h3>提醒事项</h3>
+          ${overdueProjects.length
+            ? `<p style="color:#b91c1c; font-weight:600;">逾期项目（${overdueProjects.length}）：${overdueProjects
+                .map((p) => p.name)
+                .join("，")}</p>`
+            : ""}
+          ${dueSoonProjects.length
+            ? `<p>即将到期（5天内）：${dueSoonProjects.map((p) => p.name).join("，")}</p>`
+            : ""}
+        </div>
+      `;
     }
 
-    function retry() {
-      if (wrong.length === 0) return;
-      questions.length = 0;
-      questions.push(...wrong);
-      wrong = [];
-      current = 0;
-      score = 0;
-      answered = false;
-      render();
+    function renderSuggestions() {
+      const { highRisk, dueSoon, inProgress } = calcSummary();
+      const suggestions = [];
+
+      if (highRisk > 0) {
+        suggestions.push("存在风险项目，建议安排专项会议确认资源与停机窗口，确保隐患按计划消除。");
+      }
+
+      if (dueSoon >= Math.max(1, Math.round(inProgress / 2))) {
+        suggestions.push("即将到期项目较多，可考虑调配人手或与生产协调夜班施工以保证节点。");
+      }
+
+      if (!suggestions.length) {
+        suggestions.push("项目总体平衡，建议继续保持每周例会检查进度并记录经验。",
+          "将已完成项目沉淀为标准作业流程，方便后续复制应用。"
+        );
+      }
+
+      suggestionsEl.innerHTML = `
+        <div class="card">
+          <h3>系统建议</h3>
+          <ul style="margin: 0; padding-left: 20px; line-height: 1.6;">
+            ${suggestions.map((text) => `<li>${text}</li>`).join("")}
+          </ul>
+        </div>
+      `;
+
+      tipsEl.textContent = suggestions[0];
     }
 
-    render();
+    function handleAction(action, id) {
+      const index = projects.findIndex((p) => p.id === id);
+      if (index === -1) return;
+      const project = projects[index];
+
+      if (action === "complete") {
+        project.status = "已完成";
+        project.lastUpdated = new Date().toISOString();
+      }
+
+      if (action === "archive") {
+        project.status = "已归档";
+        project.lastUpdated = new Date().toISOString();
+      }
+
+      if (action === "update") {
+        const next = prompt("下一步计划", project.nextStep || "");
+        if (next !== null) {
+          project.nextStep = next.trim();
+          const date = prompt("计划完成日期 (YYYY-MM-DD)", project.nextStepDate ? formatDate(project.nextStepDate) : "");
+          if (date) {
+            project.nextStepDate = date;
+          }
+          project.lastUpdated = new Date().toISOString();
+        }
+      }
+
+      if (action === "remove") {
+        const ok = confirm(`确认删除项目：${project.name}？`);
+        if (ok) {
+          projects.splice(index, 1);
+        }
+      }
+
+      persistProjects();
+      buildSummary();
+      renderProjects();
+      renderReminders();
+      renderSuggestions();
+    }
+
+    document.getElementById("projectForm").addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      const newProject = {
+        id: crypto.randomUUID(),
+        name: document.getElementById("projectName").value.trim(),
+        client: document.getElementById("projectClient").value.trim(),
+        owner: document.getElementById("projectOwner").value.trim(),
+        status: "进行中",
+        stage: document.getElementById("projectStage").value.trim(),
+        priority: document.getElementById("projectPriority").value,
+        dueDate: document.getElementById("projectDue").value,
+        nextStep: document.getElementById("projectNextStep").value.trim(),
+        nextStepDate: document.getElementById("projectNextStepDate").value,
+        notes: document.getElementById("projectNotes").value.trim(),
+        lastUpdated: new Date().toISOString()
+      };
+
+      projects.unshift(newProject);
+      persistProjects();
+
+      event.target.reset();
+      document.getElementById("projectPriority").value = "中";
+
+      buildSummary();
+      renderProjects();
+      renderReminders();
+      renderSuggestions();
+    });
+
+    buildSummary();
+    renderFilters();
+    renderProjects();
+    renderReminders();
+    renderSuggestions();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the quiz page with a factory engineering project assistant dashboard tailored to project follow-up
- add filterable project listings, reminders, and optimization suggestions with local storage persistence
- provide a form to capture new projects and quick actions to更新进度、归档或删除

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89f0099b08321aaa2e0fe6080b44b